### PR TITLE
Fix: Stabilize layout of Today's Soul Message section

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,17 +817,19 @@ body.modal-open #wisdom {
         }
         
         #wisdom .bg-white.bg-opacity-70 {
-            min-height: 180px;
+            min-height: 10em;
             display: flex;
             flex-direction: column;
             justify-content: center;
-            transition: height 0.3s ease-out;
+            /* transition: height 0.3s ease-out; */ /* Removed as per request */
         }
         
-        #wisdom .relative.h-64 {
-            height: 256px; /* Add fixed height */
-            min-height: 256px;
-            contain: layout paint style;
+        #wisdom .quote-carousel-container {
+            min-height: 10em;
+            transition: height 0.3s ease-out;
+            /* height: 256px; */ /* Removed as per request */
+            /* min-height: 256px; */ /* Removed as per request */
+            /* contain: layout paint style; */ /* Removed as per request */
             
         }
 
@@ -967,7 +969,7 @@ body.modal-open #wisdom {
                 </button>
 </div>
 <!-- Quote Carousel -->
-<div class="relative h-64 overflow-hidden rounded-lg bg-white bg-opacity-70 backdrop-filter backdrop-blur-sm scroll-animate">
+<div class="relative overflow-hidden rounded-lg bg-white bg-opacity-70 backdrop-filter backdrop-blur-sm scroll-animate quote-carousel-container">
 <div class="quote-slide active p-8">
 <i class="fas fa-quote-left text-3xl text-purple-300 mb-4"></i>
 <p class="text-xl md:text-2xl font-medium text-gray-700 mb-4">"The wound is the place where the Light enters you."</p>


### PR DESCRIPTION
The layout of the "Today's Soul Message" section (identified by #wisdom) was breaking when you interacted with it, such as hovering, clicking "New Message", or navigating the quote carousel. This was caused by a combination of fixed heights, CSS containment, and conflicts between CSS transitions and JavaScript height manipulation.

I've addressed the issue by:
- Removing the `h-64` Tailwind class and CSS fixed heights from the quote carousel container, allowing its height to be determined by the active quote's content.
- Adding `min-height: 10em;` to the carousel container and the wisdom message container to prevent collapse with very short content.
- Removing the `contain: layout paint style;` property from the quote carousel container, which was interfering with dynamic height adjustments.
- Removing the CSS `transition: height` from the main wisdom message container to prevent conflicts with JavaScript-driven height changes, prioritizing stability.
- Adding a CSS `transition: height` to the quote carousel container for smoother visual adjustments when the active quote (and thus height) changes.
- Introduced a new class `quote-carousel-container` for more specific CSS targeting of the carousel.

These changes ensure that the section components can dynamically adjust to their content without causing unexpected layout shifts or element overlaps.