### PR TITLE
Fix: Correct founder modal overflow, styling, and behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -518,6 +518,11 @@ body.modal-open #wisdom {
             transition: transform 0.3s ease;
             }
 
+        .founder-modal-close-button:hover {
+            transform: rotate(90deg);
+            color: #8a6ea8;
+        }
+
         .modal-close:hover {
             transform: rotate(90deg);
             color: #8a6ea8;
@@ -557,15 +562,16 @@ body.modal-open #wisdom {
         
         /* Founder Modal Specific Styles */
         .founder-modal-content {
-            background: linear-gradient(135deg, rgba(248, 233, 216, 0.95) 0%, rgba(232, 216, 200, 0.95) 100%);
+            background-color: rgba(255, 255, 255, 0.95);
             border-radius: 16px;
             width: 90%;
-            max-width: 600px;
-            padding: 40px;
+            max-width: 500px;
+            padding: 30px;
             position: relative;
-            box-shadow: 0 15px 35px rgba(0, 0, 0, 0.1);
-            border: 1px solid rgba(216, 196, 232, 0.3);
-            backdrop-filter: blur(5px);
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            border: 1px solid rgba(232, 196, 216, 0.3);
+            max-height: 90vh;
+            overflow-y: auto;
         }
         
         .founder-image {


### PR DESCRIPTION
Addresses issue where the "Meet Our Founder" modal (founderModal) was overflowing, not styled consistently with other site modals, and lacked expected scroll/close-button behavior.

Changes:
- Applied `max-height: 90vh` and `overflow-y: auto` directly to `.founder-modal-content` to ensure it's scrollable and contained on all screen sizes, resolving the overflow.
- Aligned the styling of `.founder-modal-content` with the generic `.modal-content` class by:
    - Changing background to `rgba(255, 255, 255, 0.95)`.
    - Setting `max-width` to `500px`.
    - Adjusting `padding` to `30px`.
    - Standardizing `border` and `box-shadow`.
    - Removing `backdrop-filter: blur(5px)`.
- Added a CSS hover effect (`transform: rotate(90deg)`) to `.founder-modal-close-button` to match other modal close buttons.
- Verified that existing JavaScript correctly handles modal opening/closing, smooth fade-in, and scroll-locking of the background page.

The modal should now be centered, properly sized, scrollable when content is long, styled consistently, and have the correct close button animation.